### PR TITLE
Remove StatusBar feature

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -27,9 +27,6 @@
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />
     <preference name="SplashShowOnlyFirstTime" value="false" />
-    <feature name="StatusBar">
-        <param name="ios-package" onload="true" value="CDVStatusBar" />
-    </feature>
     <plugin name="ionic-plugin-keyboard" spec="~2.2.1" />
     <plugin name="cordova-plugin-whitelist" spec="1.3.1" />
     <plugin name="cordova-plugin-console" spec="1.0.5" />


### PR DESCRIPTION
This is not needed, statusbar plugin already writes that on the platform config.xml, you don't have to manually add it. It's a mistake on the docs that has been propagated on all Ionic apps